### PR TITLE
Add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.go]
+indent_style = tab
+indent_size = 4
+max_line_length = 80


### PR DESCRIPTION
To enforce the same coding style, we could use [EditorConfig](https://editorconfig.org/), which is supported by many editors. The `.editorconfig` file in this PR is inspired by [Gogs](https://github.com/gogs/gogs/blob/master/.editorconfig).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/orderedmap/9)
<!-- Reviewable:end -->
