### PR TITLE
Add a maxSize to the ordered map, to create a ring-buffer-like behavior

### DIFF
--- a/element.go
+++ b/element.go
@@ -2,6 +2,7 @@ package orderedmap
 
 import "container/list"
 
+// Element the ordered map data structure
 type Element struct {
 	Key, Value interface{}
 

--- a/element_test.go
+++ b/element_test.go
@@ -1,9 +1,10 @@
 package orderedmap_test
 
 import (
-	"github.com/elliotchance/orderedmap"
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/prgsmall/orderedmap"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestElement_Key(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/elliotchance/orderedmap
+module github.com/prgsmall/orderedmap
 
 go 1.12
 

--- a/orderedmap.go
+++ b/orderedmap.go
@@ -6,15 +6,28 @@ type orderedMapElement struct {
 	key, value interface{}
 }
 
+// OrderedMap the ordered map data structure
 type OrderedMap struct {
-	kv map[interface{}]*list.Element
-	ll *list.List
+	kv      map[interface{}]*list.Element
+	ll      *list.List
+	maxSize int
 }
 
+// NewOrderedMap creates a new ordered map of unlimited size
 func NewOrderedMap() *OrderedMap {
 	return &OrderedMap{
-		kv: make(map[interface{}]*list.Element),
-		ll: list.New(),
+		kv:      make(map[interface{}]*list.Element),
+		ll:      list.New(),
+		maxSize: -1,
+	}
+}
+
+// NewOrderedMapWithMaxSize creates a new ordered map with a maximum size
+func NewOrderedMapWithMaxSize(max int) *OrderedMap {
+	return &OrderedMap{
+		kv:      make(map[interface{}]*list.Element),
+		ll:      list.New(),
+		maxSize: max,
 	}
 }
 
@@ -31,11 +44,15 @@ func (m *OrderedMap) Get(key interface{}) (interface{}, bool) {
 
 // Set will set (or replace) a value for a key. If the key was new, then true
 // will be returned. The returned value will be false if the value was replaced
-// (even if the value was the same).
+// (even if the value was the same).  If a new key is being added and the map is
+// full, then the front element will be deleted to make room for the new element.
 func (m *OrderedMap) Set(key, value interface{}) bool {
 	_, didExist := m.kv[key]
 
 	if !didExist {
+		if m.IsFull() {
+			m.Delete(m.Front().Key)
+		}
 		element := m.ll.PushBack(&orderedMapElement{key, value})
 		m.kv[key] = element
 	} else {
@@ -58,6 +75,16 @@ func (m *OrderedMap) GetOrDefault(key, defaultValue interface{}) interface{} {
 // Len returns the number of elements in the map.
 func (m *OrderedMap) Len() int {
 	return len(m.kv)
+}
+
+// Max returns the maximum size of the map
+func (m *OrderedMap) Max() int {
+	return m.maxSize
+}
+
+// IsFull returns true if the number of elements in the map is maxSize
+func (m *OrderedMap) IsFull() bool {
+	return m.maxSize != -1 && m.Len() == m.maxSize
 }
 
 // Keys returns all of the keys in the order they were inserted. If a key was

--- a/orderedmap_test.go
+++ b/orderedmap_test.go
@@ -9,9 +9,21 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestNewOrderedMap(t *testing.T) {
-	m := orderedmap.NewOrderedMap()
-	assert.IsType(t, &orderedmap.OrderedMap{}, m)
+func TestObjectCreation(t *testing.T) {
+	t.Run("TestNewOrderedMap", func(t *testing.T) {
+		m := orderedmap.NewOrderedMap()
+		assert.IsType(t, &orderedmap.OrderedMap{}, m)
+		assert.EqualValues(t, -1, m.Max())
+		assert.EqualValues(t, false, m.IsFull())
+	})
+
+	t.Run("TestNewOrderedMapWithMaxSize", func(t *testing.T) {
+		size := 777
+		m := orderedmap.NewOrderedMapWithMaxSize(size)
+		assert.IsType(t, &orderedmap.OrderedMap{}, m)
+		assert.Equal(t, size, m.Max())
+		assert.EqualValues(t, false, m.IsFull())
+	})
 }
 
 func TestGet(t *testing.T) {
@@ -151,6 +163,25 @@ func TestLen(t *testing.T) {
 		m.Set(2, true)
 		m.Set(3, true)
 		assert.Equal(t, 3, m.Len())
+	})
+
+	t.Run("ThreeElementsWithMax", func(t *testing.T) {
+		m := orderedmap.NewOrderedMapWithMaxSize(3)
+		assert.Equal(t, false, m.IsFull())
+		m.Set(1, true)
+		assert.Equal(t, false, m.IsFull())
+		m.Set(2, true)
+		assert.Equal(t, false, m.IsFull())
+		m.Set(3, true)
+		assert.Equal(t, 3, m.Len())
+		assert.Equal(t, true, m.IsFull())
+		assert.Equal(t, m.Front().Key, 1)
+
+		m.Set(4, true)
+		assert.Equal(t, 3, m.Len())
+		assert.Equal(t, true, m.IsFull())
+		assert.Equal(t, m.Front().Key, 2)
+		assert.Equal(t, m.Back().Key, 4)
 	})
 
 	t.Run("Performance", func(t *testing.T) {

--- a/orderedmap_test.go
+++ b/orderedmap_test.go
@@ -5,7 +5,7 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/elliotchance/orderedmap"
+	"github.com/prgsmall/orderedmap"
 	"github.com/stretchr/testify/assert"
 )
 


### PR DESCRIPTION
On the needs for a project that I am working on is to have a ring buffer map that would show a windows of parsed lines indexed by ids that are parsed from each line.  I've modified ordered map to take an optional maxSize field, which can be set at creation time to ensure this behavior.

It add a new New...  method and Max(), IsFull() methods, and modifies the Set to delete the Front() element if Max() has been met.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/orderedmap/14)
<!-- Reviewable:end -->
