### PR TITLE
Adds Copy() function

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/elliotchance/orderedmap
 
 go 1.12
 
-require github.com/stretchr/testify v1.4.0
+require github.com/stretchr/testify v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -5,7 +5,11 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/orderedmap.go
+++ b/orderedmap.go
@@ -138,7 +138,8 @@ func (m *OrderedMap) Back() *Element {
 }
 
 // Copy returns a new OrderedMap with the same elements.
-// The elements deep copied. That is changes to the original OrderedMap will not affect elements in the new OrderedMap.
+// The elements deep copied. That is changes to the original OrderedMap will
+// not affect elements in the new OrderedMap.
 // Using Copy while there are concurrent writes may mangle the result.
 func (m *OrderedMap) Copy() *OrderedMap {
 	m2 := NewOrderedMap()

--- a/orderedmap.go
+++ b/orderedmap.go
@@ -137,9 +137,15 @@ func (m *OrderedMap) Back() *Element {
 	}
 }
 
-// Copy will return a pointer to a new instances OrderedMap that is
-// a copy of the existing one
+// Copy returns a new OrderedMap with the same elements.
+// The elements deep copied. That is changes to the original OrderedMap will not affect elements in the new OrderedMap.
+// Using Copy while there are concurrent writes may mangle the result.
 func (m *OrderedMap) Copy() *OrderedMap {
-	m2 := *m
-	return &m2
+	m2 := NewOrderedMap()
+
+	for el := m.Front(); el != nil; el = el.Next() {
+		m2.Set(el.Key, el.Value)
+	}
+
+	return m2
 }

--- a/orderedmap.go
+++ b/orderedmap.go
@@ -138,8 +138,6 @@ func (m *OrderedMap) Back() *Element {
 }
 
 // Copy returns a new OrderedMap with the same elements.
-// The elements are deep copied. That is changes to the original OrderedMap will
-// not affect elements in the new OrderedMap returned.
 // Using Copy while there are concurrent writes may mangle the result.
 func (m *OrderedMap) Copy() *OrderedMap {
 	m2 := NewOrderedMap()

--- a/orderedmap.go
+++ b/orderedmap.go
@@ -136,3 +136,10 @@ func (m *OrderedMap) Back() *Element {
 		Value:   element.value,
 	}
 }
+
+// Copy will return a pointer to a new instances OrderedMap that is
+// a copy of the existing one
+func (m *OrderedMap) Copy() *OrderedMap {
+	m2 := *m
+	return &m2
+}

--- a/orderedmap.go
+++ b/orderedmap.go
@@ -138,8 +138,8 @@ func (m *OrderedMap) Back() *Element {
 }
 
 // Copy returns a new OrderedMap with the same elements.
-// The elements deep copied. That is changes to the original OrderedMap will
-// not affect elements in the new OrderedMap.
+// The elements are deep copied. That is changes to the original OrderedMap will
+// not affect elements in the new OrderedMap returned.
 // Using Copy while there are concurrent writes may mangle the result.
 func (m *OrderedMap) Copy() *OrderedMap {
 	m2 := NewOrderedMap()

--- a/orderedmap_test.go
+++ b/orderedmap_test.go
@@ -306,11 +306,15 @@ func TestOrderedMap_Back(t *testing.T) {
 
 func TestOrderedMap_Copy(t *testing.T) {
 	t.Run("ReturnsEqualButNotSame", func(t *testing.T) {
+		key, value := 1, "a value"
 		m := orderedmap.NewOrderedMap()
-		m2 := m.Copy()
+		m.Set(key, value)
 
-		assert.Equal(t, m, m2)
-		assert.NotSame(t, m, m2)
+		m2 := m.Copy()
+		m2.Set(key, "a different value")
+
+		assert.Equal(t, m.Len(), m2.Len(), "not all elements are copied")
+		assert.Equal(t, value, m.GetElement(key).Value)
 	})
 }
 

--- a/orderedmap_test.go
+++ b/orderedmap_test.go
@@ -304,6 +304,16 @@ func TestOrderedMap_Back(t *testing.T) {
 	})
 }
 
+func TestOrderedMap_Copy(t *testing.T) {
+	t.Run("ReturnsEqualButNotSame", func(t *testing.T) {
+		m := orderedmap.NewOrderedMap()
+		m2 := m.Copy()
+
+		assert.Equal(t, m, m2)
+		assert.NotSame(t, m, m2)
+	})
+}
+
 func TestGetElement(t *testing.T) {
 	t.Run("ReturnsElementForKey", func(t *testing.T) {
 		m := orderedmap.NewOrderedMap()


### PR DESCRIPTION
As per discussion on [PR #10](https://github.com/elliotchance/mocksqs/pull/10) for [elliotchance/mocksqs](https://github.com/elliotchance/mocksqs) adding `Copy()`.

Note: I've not added any benchmarking for `Copy()`. I had a look and wanted to check in first, to confirm if that was needed or not :)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/orderedmap/19)
<!-- Reviewable:end -->
