### PR TITLE
fix: ci build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 language: go
 
 go:
-  - 1.11.x
-  - 1.12.x
+  - 1.13.x
   - master
 
 script:

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/elliotchance/orderedmap
 
-go 1.12
+go 1.13
 
 require github.com/stretchr/testify v1.7.0


### PR DESCRIPTION
testify 1.7.0 requires go >=1.13

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/orderedmap/24)
<!-- Reviewable:end -->
