### PR TITLE
Support JSON marshal

### DIFF
--- a/v2/go.mod
+++ b/v2/go.mod
@@ -3,9 +3,12 @@ module github.com/elliotchance/orderedmap/v2
 go 1.18
 
 require (
+	github.com/stretchr/testify v1.7.1
+	golang.org/x/exp v0.0.0-20220321173239-a90fa8a75705
+)
+
+require (
 	github.com/davecgh/go-spew v1.1.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/stretchr/testify v1.7.1 // indirect
-	golang.org/x/exp v0.0.0-20220321173239-a90fa8a75705 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
 )

--- a/v2/go.sum
+++ b/v2/go.sum
@@ -7,6 +7,7 @@ github.com/stretchr/testify v1.7.1 h1:5TQK59W5E3v0r2duFAb7P95B6hEeOyEnHRa8MjYSMT
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 golang.org/x/exp v0.0.0-20220321173239-a90fa8a75705 h1:ba9YlqfDGTTQ5aZ2fwOoQ1hf32QySyQkR6ODGDzHlnE=
 golang.org/x/exp v0.0.0-20220321173239-a90fa8a75705/go.mod h1:lgLbSvA5ygNOMpwM/9anMpWVlVJ7Z+cHWq/eFuinpGE=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/v2/orderedmap.go
+++ b/v2/orderedmap.go
@@ -1,7 +1,10 @@
 package orderedmap
 
 import (
+	"bytes"
 	"container/list"
+	"encoding/json"
+
 	"golang.org/x/exp/constraints"
 )
 
@@ -151,4 +154,29 @@ func (m *OrderedMap[K, V]) Copy() *OrderedMap[K, V] {
 	}
 
 	return m2
+}
+
+// Implements JSON marshaling.
+func (m *OrderedMap[string, V]) MarshalJSON() ([]byte, error) {
+	if m.Len() == 0 {
+		return []byte("{}"), nil
+	}
+	var buf bytes.Buffer
+	buf.WriteByte('{')
+	encoder := json.NewEncoder(&buf)
+	for el := m.Front(); el != nil; el = el.Next() {
+		// add key
+		if err := encoder.Encode(el.Key); err != nil {
+			return nil, err
+		}
+		buf.WriteByte(':')
+		// add value
+		if err := encoder.Encode(el.Value); err != nil {
+			return nil, err
+		}
+		buf.WriteByte(',')
+	}
+	buf.Truncate(buf.Len() - 1)
+	buf.WriteByte('}')
+	return buf.Bytes(), nil
 }


### PR DESCRIPTION
Great library!

I've read your comment on PR #16 about creating a type alias to implement JSON marshal, but with v2 generics that isn't possible:

```go
type omap = orderedmap.OrderedMap // Err: cannot use generic type orderedmap.OrderedMap[K constraints.Ordered, V any] without instantiation

// with instantiation
type omap = orderedmap.OrderedMap[string, any]

func (m *omap) MarshalJSON() ([]byte, error) { // Err: cannot define methods on instantiated type *orderedmap.OrderedMap[string, any]
	return nil, nil
}
```

It is being discussed here: https://github.com/golang/go/issues/46477