### PR TITLE
Require comparable interface instead of constraints.Ordered for map keys

### DIFF
--- a/v2/element.go
+++ b/v2/element.go
@@ -2,17 +2,16 @@ package orderedmap
 
 import (
 	"container/list"
-	"golang.org/x/exp/constraints"
 )
 
-type Element[K constraints.Ordered, V any] struct {
+type Element[K comparable, V any] struct {
 	Key   K
 	Value V
 
 	element *list.Element
 }
 
-func newElement[K constraints.Ordered, V any](e *list.Element) *Element[K, V] {
+func newElement[K comparable, V any](e *list.Element) *Element[K, V] {
 	if e == nil {
 		return nil
 	}

--- a/v2/orderedmap.go
+++ b/v2/orderedmap.go
@@ -2,20 +2,19 @@ package orderedmap
 
 import (
 	"container/list"
-	"golang.org/x/exp/constraints"
 )
 
-type orderedMapElement[K constraints.Ordered, V any] struct {
+type orderedMapElement[K comparable, V any] struct {
 	key   K
 	value V
 }
 
-type OrderedMap[K constraints.Ordered, V any] struct {
+type OrderedMap[K comparable, V any] struct {
 	kv map[K]*list.Element
 	ll *list.List
 }
 
-func NewOrderedMap[K constraints.Ordered, V any]() *OrderedMap[K, V] {
+func NewOrderedMap[K comparable, V any]() *OrderedMap[K, V] {
 	return &OrderedMap[K, V]{
 		kv: make(map[K]*list.Element),
 		ll: list.New(),


### PR DESCRIPTION
Hello, nice package.
Maybe I am wrong but I don't see the added value of constraining the key type using `constraints.Ordered`.

Without this constraint this map could be "a drop in replacement" for the standard map type when the user is interested in preserving the insertion order.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/orderedmap/29)
<!-- Reviewable:end -->
