### PR TITLE
Implement Go 1.23 iterators

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,10 +6,16 @@ on:
 
 jobs:
   unit-tests:
+    strategy:
+      matrix:
+        go:
+          - '=1.18'
+          - '^1.23'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: '>=1.18.0'
-      - run: go test
+          go-version: ${{ matrix.go }}
+      - run: go test -v ./...
+      - run: cd v2 && go test -v ./...

--- a/README.md
+++ b/README.md
@@ -52,6 +52,20 @@ for el := m.Back(); el != nil; el = el.Prev() {
 }
 ```
 
+In case you're using Go 1.23, you can also [iterate with
+`range`](https://go.dev/doc/go1.23#iterators) by using `Iterator()` or
+`ReverseIterator()` methods:
+
+```go
+for key, value := range m.Iterator() {
+    fmt.Println(key, value)
+}
+
+for key, value := range m.ReverseIterator() {
+    fmt.Println(key, value)
+}
+```
+
 The iterator is safe to use bidirectionally, and will return `nil` once it goes
 beyond the first or last item.
 

--- a/v2/iterator.go
+++ b/v2/iterator.go
@@ -1,0 +1,26 @@
+//go:build go1.23
+// +build go1.23
+
+package orderedmap
+
+import "iter"
+
+func (m *OrderedMap[K, V]) Iterator() iter.Seq2[K, V] {
+	return func(yield func(key K, value V) bool) {
+		for el := m.Front(); el != nil; el = el.Next() {
+			if !yield(el.Key, el.Value) {
+				return
+			}
+		}
+	}
+}
+
+func (m *OrderedMap[K, V]) ReverseIterator() iter.Seq2[K, V] {
+	return func(yield func(key K, value V) bool) {
+		for el := m.Back(); el != nil; el = el.Prev() {
+			if !yield(el.Key, el.Value) {
+				return
+			}
+		}
+	}
+}

--- a/v2/iterator_test.go
+++ b/v2/iterator_test.go
@@ -1,0 +1,41 @@
+//go:build go1.23
+// +build go1.23
+
+package orderedmap_test
+
+import (
+	"testing"
+
+	"github.com/elliotchance/orderedmap/v2"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIterators(t *testing.T) {
+	type Element struct {
+		Key   int
+		Value bool
+	}
+	m := orderedmap.NewOrderedMap[int, bool]()
+	expected := []Element{{5, true}, {3, false}, {1, false}, {4, true}}
+	for _, v := range expected {
+		m.Set(v.Key, v.Value)
+	}
+
+	t.Run("Iterator", func(t *testing.T) {
+		i := 0
+		for key, value := range m.Iterator() {
+			assert.Equal(t, expected[i].Key, key)
+			assert.Equal(t, expected[i].Value, value)
+			i++
+		}
+	})
+
+	t.Run("ReverseIterator", func(t *testing.T) {
+		i := len(expected) - 1
+		for key, value := range m.ReverseIterator() {
+			assert.Equal(t, expected[i].Key, key)
+			assert.Equal(t, expected[i].Value, value)
+			i--
+		}
+	})
+}


### PR DESCRIPTION
Close issue: https://github.com/elliotchance/orderedmap/issues/40.

This PR implements `Iterator()` and `ReverseIterator()` methods, that allow usage with `for ... range` in Go 1.23:

```go
for key, value := range m.Iterator() {
    fmt.Println(key, value)
}

for key, value := range m.ReverseIterator() {
    fmt.Println(key, value)
}
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/orderedmap/41)
<!-- Reviewable:end -->
