### PR TITLE
Allow initial elements as variadic into NewOrderedMap

### DIFF
--- a/v2/orderedmap.go
+++ b/v2/orderedmap.go
@@ -11,6 +11,16 @@ func NewOrderedMap[K comparable, V any]() *OrderedMap[K, V] {
 	}
 }
 
+func NewOrderedMapWithElements[K comparable, V any](els ...*Element[K, V]) *OrderedMap[K, V] {
+	om := &OrderedMap[K, V]{
+		kv: make(map[K]*Element[K, V], len(els)),
+	}
+	for _, el := range els {
+		om.Set(el.Key, el.Value)
+	}
+	return om
+}
+
 // Get returns the value for a key. If the key does not exist, the second return
 // parameter will be false and the value will be nil.
 func (m *OrderedMap[K, V]) Get(key K) (value V, ok bool) {


### PR DESCRIPTION
Closes #43 

Adds a variadic argument to `NewOrderedMap` which allows the user to specify a set of initial data when initialising an ordered map. In my initial proposal I suggested a new function called `NewOrderedMapWithElements`. However, this isn't necessary to maintain backwards compatibility since the argument is variadic and still works when no arguments are set.

I also considered a functional options style API which would allow for greater compatibility with any future changes:

```go
type OrderedMapOption[K comparable, V any] func(*OrderedMap[K, V])

type OrderedMap[K comparable, V any] struct {
	kv map[K]*Element[K, V]
	ll list[K, V]
}

func NewOrderedMap[K comparable, V any](opts ...OrderedMapOption[K, V]) *OrderedMap[K, V] {
	om := &OrderedMap[K, V]{
		kv: make(map[K]*Element[K, V]),
	}
	for _, opt := range opts {
		opt(om)
	}
	return om
}

func WithInitialData[K comparable, V any](els ...*Element[K, V]) OrderedMapOption[K, V] {
	return func(m *OrderedMap[K, V]) {
		for _, el := range els {
			m.Set(el.Key, el.Value)
		}
	}
}
```

However, this may be overkill for what is currently quite a simple API. It also loses the ability to initialise the underlying map with the correct size.

We could consider setting the size of the underlying list too, but I assume you are not doing this currently to save allocations. Maybe we only initialise if `len(els) > 0`?

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/orderedmap/45)
<!-- Reviewable:end -->
