### PR TITLE
perf: allow pre-allocate of size when new map

### DIFF
--- a/orderedmap.go
+++ b/orderedmap.go
@@ -11,6 +11,14 @@ func NewOrderedMap() *OrderedMap {
 	}
 }
 
+// NewOrderedMapWithCapacity creates a map with enough pre-allocated space to
+// hold the specified number of elements.
+func NewOrderedMapWithCapacity(capacity int) *OrderedMap {
+	return &OrderedMap{
+		kv: make(map[interface{}]*Element, capacity),
+	}
+}
+
 // Get returns the value for a key. If the key does not exist, the second return
 // parameter will be false and the value will be nil.
 func (m *OrderedMap) Get(key interface{}) (interface{}, bool) {

--- a/orderedmap_test.go
+++ b/orderedmap_test.go
@@ -761,6 +761,21 @@ func BenchmarkBigOrderedMap_Set(b *testing.B) {
 	benchmarkBigOrderedMap_Set()(b)
 }
 
+func benchmarkBigMapWithCapacity_Set() func(b *testing.B) {
+	return func(b *testing.B) {
+		for j := 0; j < b.N; j++ {
+			m := orderedmap.NewOrderedMapWithCapacity(10000000)
+			for i := 0; i < 10000000; i++ {
+				m.Set(i, true)
+			}
+		}
+	}
+}
+
+func BenchmarkBigMapWithCapacity_Set(b *testing.B) {
+	benchmarkBigMapWithCapacity_Set()(b)
+}
+
 func benchmarkBigMap_Get() func(b *testing.B) {
 	m := make(map[int]bool)
 	for i := 0; i < 10000000; i++ {

--- a/v2/orderedmap.go
+++ b/v2/orderedmap.go
@@ -11,6 +11,14 @@ func NewOrderedMap[K comparable, V any]() *OrderedMap[K, V] {
 	}
 }
 
+// NewOrderedMapWithCapacity creates a map with enough pre-allocated space to
+// hold the specified number of elements.
+func NewOrderedMapWithCapacity[K comparable, V any](capacity int) *OrderedMap[K, V] {
+	return &OrderedMap[K, V]{
+		kv: make(map[K]*Element[K, V], capacity),
+	}
+}
+
 func NewOrderedMapWithElements[K comparable, V any](els ...*Element[K, V]) *OrderedMap[K, V] {
 	om := &OrderedMap[K, V]{
 		kv: make(map[K]*Element[K, V], len(els)),

--- a/v2/orderedmap_test.go
+++ b/v2/orderedmap_test.go
@@ -730,6 +730,21 @@ func BenchmarkBigOrderedMap_Set(b *testing.B) {
 	benchmarkBigOrderedMap_Set()(b)
 }
 
+func benchmarkBigMapWithCapacity_Set() func(b *testing.B) {
+	return func(b *testing.B) {
+		for j := 0; j < b.N; j++ {
+			m := orderedmap.NewOrderedMapWithCapacity[int, bool](10000000)
+			for i := 0; i < 10000000; i++ {
+				m.Set(i, true)
+			}
+		}
+	}
+}
+
+func BenchmarkBigMapWithCapacity_Set(b *testing.B) {
+	benchmarkBigMapWithCapacity_Set()(b)
+}
+
 func benchmarkBigMap_Get() func(b *testing.B) {
 	m := make(map[int]bool)
 	for i := 0; i < 10000000; i++ {


### PR DESCRIPTION
There is a simple result from the bench test:
|entries|withInitialedSize|withoutInitialedSize|rate|
|-------|------|----|---|
| 1e3 | 41153 ns/op  | 72909 ns/op | 56.44% |
|1e5 | 7523395 ns/op | 9731575 ns/op | 77.31% |
|1e7 | 2005930041 ns/op | 2555268041 ns/op | 78.50% |

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/orderedmap/48)
<!-- Reviewable:end -->
