### PR TITLE
Construct the backing map with predefined length

### DIFF
--- a/v2/orderedmap.go
+++ b/v2/orderedmap.go
@@ -11,10 +11,14 @@ func NewOrderedMap[K comparable, V any]() *OrderedMap[K, V] {
 	}
 }
 
-func NewOrderedMapWithElements[K comparable, V any](els ...*Element[K, V]) *OrderedMap[K, V] {
-	om := &OrderedMap[K, V]{
-		kv: make(map[K]*Element[K, V], len(els)),
+func NewOrderedMapWithLen[K comparable, V any](l int) *OrderedMap[K, V] {
+	return &OrderedMap[K, V]{
+		kv: make(map[K]*Element[K, V], l),
 	}
+}
+
+func NewOrderedMapWithElements[K comparable, V any](els ...*Element[K, V]) *OrderedMap[K, V] {
+	om := NewOrderedMapWithLen[K, V](len(els))
 	for _, el := range els {
 		om.Set(el.Key, el.Value)
 	}
@@ -126,7 +130,7 @@ func (m *OrderedMap[K, V]) Back() *Element[K, V] {
 // Copy returns a new OrderedMap with the same elements.
 // Using Copy while there are concurrent writes may mangle the result.
 func (m *OrderedMap[K, V]) Copy() *OrderedMap[K, V] {
-	m2 := NewOrderedMap[K, V]()
+	m2 := NewOrderedMapWithLen[K, V](m.Len())
 	for el := m.Front(); el != nil; el = el.Next() {
 		m2.Set(el.Key, el.Value)
 	}


### PR DESCRIPTION
It would be efficient to create a backing array with a predefined length if we know the average number of elements to be stored. It will eliminate the need for rehashing in the underlying map.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/orderedmap/49)
<!-- Reviewable:end -->
