### PR TITLE
Json marshal implementation

### DIFF
--- a/v2/marshal.go
+++ b/v2/marshal.go
@@ -1,0 +1,58 @@
+package orderedmap
+
+import (
+	"bytes"
+	"encoding"
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"strconv"
+)
+
+func (m *OrderedMap[K, V]) MarshalJSON() ([]byte, error) {
+	b := bytes.NewBuffer(make([]byte, 0, m.Len()<<3))
+	b.WriteByte('{')
+	for el := m.Front(); el != nil; el = el.Next() {
+		keyValue := reflect.ValueOf(el.Key)
+		keyStr, err := resolveKeyName(keyValue)
+		if err != nil {
+			return nil, fmt.Errorf("error resolving key: %w", err)
+		}
+		key, err := json.Marshal(keyStr)
+		if err != nil {
+			return nil, fmt.Errorf("error marshaling key %v: %w", el.Key, err)
+		}
+		b.Write(key)
+		b.WriteByte(':')
+		value, err := json.Marshal(el.Value)
+		if err != nil {
+			return nil, fmt.Errorf("error marshaling value for key %v: %w", el.Key, err)
+		}
+		b.Write(value)
+		if el.Next() != nil {
+			b.WriteByte(',')
+		}
+	}
+	b.WriteByte('}')
+	return b.Bytes(), nil
+}
+
+func resolveKeyName(k reflect.Value) (string, error) {
+	if k.Kind() == reflect.String {
+		return k.String(), nil
+	}
+	if tm, ok := k.Interface().(encoding.TextMarshaler); ok {
+		if k.Kind() == reflect.Pointer && k.IsNil() {
+			return "", nil
+		}
+		buf, err := tm.MarshalText()
+		return string(buf), err
+	}
+	switch k.Kind() {
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return strconv.FormatInt(k.Int(), 10), nil
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+		return strconv.FormatUint(k.Uint(), 10), nil
+	}
+	return "", &json.UnsupportedTypeError{Type: k.Type()}
+}


### PR DESCRIPTION
It is the implementation of json marshaling that preserves the order of records as maintained by the map. This was discussed in #12, but I needed this functionality for my use case, so I went ahead and implemented it.

@elliotchance, if you still think it's unnecessary to support this in the library itself, feel free to close it or keep it as a reference for anyone who might need something similar.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/orderedmap/50)
<!-- Reviewable:end -->
