### PR TITLE
Create the target map with capacity on copy

### DIFF
--- a/orderedmap.go
+++ b/orderedmap.go
@@ -109,7 +109,7 @@ func (m *OrderedMap) Back() *Element {
 // Copy returns a new OrderedMap with the same elements.
 // Using Copy while there are concurrent writes may mangle the result.
 func (m *OrderedMap) Copy() *OrderedMap {
-	m2 := NewOrderedMap()
+	m2 := NewOrderedMapWithCapacity(m.Len())
 
 	for el := m.Front(); el != nil; el = el.Next() {
 		m2.Set(el.Key, el.Value)

--- a/v2/orderedmap.go
+++ b/v2/orderedmap.go
@@ -20,9 +20,7 @@ func NewOrderedMapWithCapacity[K comparable, V any](capacity int) *OrderedMap[K,
 }
 
 func NewOrderedMapWithElements[K comparable, V any](els ...*Element[K, V]) *OrderedMap[K, V] {
-	om := &OrderedMap[K, V]{
-		kv: make(map[K]*Element[K, V], len(els)),
-	}
+	om := NewOrderedMapWithCapacity[K, V](len(els))
 	for _, el := range els {
 		om.Set(el.Key, el.Value)
 	}
@@ -134,7 +132,7 @@ func (m *OrderedMap[K, V]) Back() *Element[K, V] {
 // Copy returns a new OrderedMap with the same elements.
 // Using Copy while there are concurrent writes may mangle the result.
 func (m *OrderedMap[K, V]) Copy() *OrderedMap[K, V] {
-	m2 := NewOrderedMap[K, V]()
+	m2 := NewOrderedMapWithCapacity[K, V](m.Len())
 	for el := m.Front(); el != nil; el = el.Next() {
 		m2.Set(el.Key, el.Value)
 	}

--- a/v3/orderedmap.go
+++ b/v3/orderedmap.go
@@ -22,9 +22,7 @@ func NewOrderedMapWithCapacity[K comparable, V any](capacity int) *OrderedMap[K,
 }
 
 func NewOrderedMapWithElements[K comparable, V any](els ...*Element[K, V]) *OrderedMap[K, V] {
-	om := &OrderedMap[K, V]{
-		kv: make(map[K]*Element[K, V], len(els)),
-	}
+	om := NewOrderedMapWithCapacity[K, V](len(els))
 	for _, el := range els {
 		om.Set(el.Key, el.Value)
 	}
@@ -175,7 +173,7 @@ func (m *OrderedMap[K, V]) Back() *Element[K, V] {
 // Copy returns a new OrderedMap with the same elements.
 // Using Copy while there are concurrent writes may mangle the result.
 func (m *OrderedMap[K, V]) Copy() *OrderedMap[K, V] {
-	m2 := NewOrderedMap[K, V]()
+	m2 := NewOrderedMapWithCapacity[K, V](m.Len())
 	for el := m.Front(); el != nil; el = el.Next() {
 		m2.Set(el.Key, el.Value)
 	}


### PR DESCRIPTION
We can create a target map with a predefined capacity equal to the length of the source map when copying.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/orderedmap/51)
<!-- Reviewable:end -->
