### PR TITLE
Add Has Method to OrderedMap

### DIFF
--- a/orderedmap.go
+++ b/orderedmap.go
@@ -117,3 +117,9 @@ func (m *OrderedMap) Copy() *OrderedMap {
 
 	return m2
 }
+
+// Has checks if a key exists in the map.
+func (m *OrderedMap[K, V]) Has(key interface{}) bool {
+	_, exists := m.kv[key]
+	return exists
+}

--- a/orderedmap_test.go
+++ b/orderedmap_test.go
@@ -357,6 +357,27 @@ func TestGetElement(t *testing.T) {
 	})
 }
 
+func TestOrderedMap_Has(t *testing.T) {
+	t.Run("ReturnsFalseIfKeyDoesNotExist", func(t *testing.T) {
+		m := orderedmap.NewOrderedMap()
+		assert.False(t, m.Has("foo"))
+	})
+
+	t.Run("ReturnsTrueIfKeyExists", func(t *testing.T) {
+		m := orderedmap.NewOrderedMap()
+		m.Set("foo", "bar")
+		assert.True(t, m.Has("foo"))
+	})
+
+	t.Run("KeyDoesNotExistAfterDelete", func(t *testing.T) {
+		m := orderedmap.NewOrderedMap()
+		m.Set("foo", "bar")
+		m.Delete("foo")
+		assert.False(t, m.Has("foo"))
+	})
+}
+
+
 func benchmarkMap_Set(multiplier int) func(b *testing.B) {
 	return func(b *testing.B) {
 		m := make(map[int]bool)
@@ -1001,6 +1022,24 @@ func BenchmarkBigOrderedMapString_Iterate(b *testing.B) {
 	benchmarkBigOrderedMapString_Iterate()(b)
 }
 
+func benchmarkOrderedMap_Has(multiplier int) func(b *testing.B) {
+	m := orderedmap.NewOrderedMap()
+	for i := 0; i < 1000*multiplier; i++ {
+		m.Set(i, true)
+	}
+
+	return func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			m.Has(i % 1000 * multiplier)
+		}
+	}
+}
+
+func BenchmarkOrderedMap_Has(b *testing.B) {
+	benchmarkOrderedMap_Has(1)(b)
+}
+
+
 func BenchmarkAll(b *testing.B) {
 	b.Run("BenchmarkOrderedMap_Keys", BenchmarkOrderedMap_Keys)
 
@@ -1013,6 +1052,7 @@ func BenchmarkAll(b *testing.B) {
 	b.Run("BenchmarkMap_Delete", BenchmarkMap_Delete)
 	b.Run("BenchmarkOrderedMap_Iterate", BenchmarkOrderedMap_Iterate)
 	b.Run("BenchmarkMap_Iterate", BenchmarkMap_Iterate)
+	b.Run("BenchmarkOrderedMap_Has", BenchmarkOrderedMap_Has)
 
 	b.Run("BenchmarkBigMap_Set", BenchmarkBigMap_Set)
 	b.Run("BenchmarkBigOrderedMap_Set", BenchmarkBigOrderedMap_Set)

--- a/v2/orderedmap.go
+++ b/v2/orderedmap.go
@@ -140,3 +140,9 @@ func (m *OrderedMap[K, V]) Copy() *OrderedMap[K, V] {
 	}
 	return m2
 }
+
+// Has checks if a key exists in the map.
+func (m *OrderedMap[K, V]) Has(key interface{}) bool {
+	_, exists := m.kv[key]
+	return exists
+}

--- a/v2/orderedmap_test.go
+++ b/v2/orderedmap_test.go
@@ -351,6 +351,27 @@ func TestIterations(t *testing.T) {
 	})
 }
 
+func TestOrderedMap_Has(t *testing.T) {
+	t.Run("ReturnsFalseIfKeyDoesNotExist", func(t *testing.T) {
+		m := orderedmap.NewOrderedMap()
+		assert.False(t, m.Has("foo"))
+	})
+
+	t.Run("ReturnsTrueIfKeyExists", func(t *testing.T) {
+		m := orderedmap.NewOrderedMap()
+		m.Set("foo", "bar")
+		assert.True(t, m.Has("foo"))
+	})
+
+	t.Run("KeyDoesNotExistAfterDelete", func(t *testing.T) {
+		m := orderedmap.NewOrderedMap()
+		m.Set("foo", "bar")
+		m.Delete("foo")
+		assert.False(t, m.Has("foo"))
+	})
+}
+
+
 func benchmarkMap_Set(multiplier int) func(b *testing.B) {
 	return func(b *testing.B) {
 		m := make(map[int]bool)
@@ -970,6 +991,23 @@ func BenchmarkBigOrderedMapString_Iterate(b *testing.B) {
 	benchmarkBigOrderedMapString_Iterate()(b)
 }
 
+func benchmarkOrderedMap_Has(multiplier int) func(b *testing.B) {
+	m := orderedmap.NewOrderedMap()
+	for i := 0; i < 1000*multiplier; i++ {
+		m.Set(i, true)
+	}
+
+	return func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			m.Has(i % 1000 * multiplier)
+		}
+	}
+}
+
+func BenchmarkOrderedMap_Has(b *testing.B) {
+	benchmarkOrderedMap_Has(1)(b)
+}
+
 func BenchmarkAll(b *testing.B) {
 	b.Run("BenchmarkOrderedMap_Keys", BenchmarkOrderedMap_Keys)
 
@@ -982,6 +1020,7 @@ func BenchmarkAll(b *testing.B) {
 	b.Run("BenchmarkMap_Delete", BenchmarkMap_Delete)
 	b.Run("BenchmarkOrderedMap_Iterate", BenchmarkOrderedMap_Iterate)
 	b.Run("BenchmarkMap_Iterate", BenchmarkMap_Iterate)
+	b.Run("BenchmarkOrderedMap_Has", BenchmarkOrderedMap_Has)
 
 	b.Run("BenchmarkBigMap_Set", BenchmarkBigMap_Set)
 	b.Run("BenchmarkBigOrderedMap_Set", BenchmarkBigOrderedMap_Set)

--- a/v3/orderedmap.go
+++ b/v3/orderedmap.go
@@ -181,3 +181,9 @@ func (m *OrderedMap[K, V]) Copy() *OrderedMap[K, V] {
 	}
 	return m2
 }
+
+// Has checks if a key exists in the map.
+func (m *OrderedMap[K, V]) Has(key interface{}) bool {
+	_, exists := m.kv[key]
+	return exists
+}

--- a/v3/orderedmap_test.go
+++ b/v3/orderedmap_test.go
@@ -381,6 +381,27 @@ func TestIterators(t *testing.T) {
 	})
 }
 
+func TestOrderedMap_Has(t *testing.T) {
+	t.Run("ReturnsFalseIfKeyDoesNotExist", func(t *testing.T) {
+		m := orderedmap.NewOrderedMap()
+		assert.False(t, m.Has("foo"))
+	})
+
+	t.Run("ReturnsTrueIfKeyExists", func(t *testing.T) {
+		m := orderedmap.NewOrderedMap()
+		m.Set("foo", "bar")
+		assert.True(t, m.Has("foo"))
+	})
+
+	t.Run("KeyDoesNotExistAfterDelete", func(t *testing.T) {
+		m := orderedmap.NewOrderedMap()
+		m.Set("foo", "bar")
+		m.Delete("foo")
+		assert.False(t, m.Has("foo"))
+	})
+}
+
+
 func benchmarkMap_Set(multiplier int) func(b *testing.B) {
 	return func(b *testing.B) {
 		m := make(map[int]bool)
@@ -987,6 +1008,24 @@ func BenchmarkBigOrderedMapString_Iterate(b *testing.B) {
 	benchmarkBigOrderedMapString_Iterate()(b)
 }
 
+func benchmarkOrderedMap_Has(multiplier int) func(b *testing.B) {
+	m := orderedmap.NewOrderedMap()
+	for i := 0; i < 1000*multiplier; i++ {
+		m.Set(i, true)
+	}
+
+	return func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			m.Has(i % 1000 * multiplier)
+		}
+	}
+}
+
+func BenchmarkOrderedMap_Has(b *testing.B) {
+	benchmarkOrderedMap_Has(1)(b)
+}
+
+
 func BenchmarkAll(b *testing.B) {
 	b.Run("BenchmarkOrderedMap_Set", BenchmarkOrderedMap_Set)
 	b.Run("BenchmarkMap_Set", BenchmarkMap_Set)
@@ -997,6 +1036,7 @@ func BenchmarkAll(b *testing.B) {
 	b.Run("BenchmarkMap_Delete", BenchmarkMap_Delete)
 	b.Run("BenchmarkOrderedMap_Iterate", BenchmarkOrderedMap_Iterate)
 	b.Run("BenchmarkMap_Iterate", BenchmarkMap_Iterate)
+	b.Run("BenchmarkOrderedMap_Has", BenchmarkOrderedMap_Has)
 
 	b.Run("BenchmarkBigMap_Set", BenchmarkBigMap_Set)
 	b.Run("BenchmarkBigOrderedMap_Set", BenchmarkBigOrderedMap_Set)


### PR DESCRIPTION
This pull request introduces the `Has` method to the OrderedMap
### Tests
- Added Unit tests to check existence and non-existence
- Added benchmark Methods.

### Usage
``` go
m := orderedmap.NewOrderedMap[int, string]()
m.Set(1, "value")
exists := m.Has(1) // returns true
notExists := m.Has(2) // returns false
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/orderedmap/53)
<!-- Reviewable:end -->
