### PR TITLE
Add Has Method for OrderedMap

### DIFF
--- a/orderedmap.go
+++ b/orderedmap.go
@@ -117,3 +117,9 @@ func (m *OrderedMap) Copy() *OrderedMap {
 
 	return m2
 }
+
+// Has checks if a key exists in the map.
+func (m *OrderedMap) Has(key interface{}) bool {
+	_, exists := m.kv[key]
+	return exists
+}

--- a/orderedmap_test.go
+++ b/orderedmap_test.go
@@ -1068,6 +1068,7 @@ func BenchmarkAll(b *testing.B) {
 	b.Run("BenchmarkMapString_Delete", BenchmarkMapString_Delete)
 	b.Run("BenchmarkOrderedMapString_Iterate", BenchmarkOrderedMapString_Iterate)
 	b.Run("BenchmarkMapString_Iterate", BenchmarkMapString_Iterate)
+	b.Run("BenchmarkOrderedMap_Has", BenchmarkOrderedMap_Has)
 
 	b.Run("BenchmarkBigMapString_Set", BenchmarkBigMapString_Set)
 	b.Run("BenchmarkBigOrderedMapString_Set", BenchmarkBigOrderedMapString_Set)

--- a/orderedmap_test.go
+++ b/orderedmap_test.go
@@ -357,6 +357,26 @@ func TestGetElement(t *testing.T) {
 	})
 }
 
+func TestOrderedMap_Has(t *testing.T) {
+	t.Run("ReturnsFalseIfKeyDoesNotExist", func(t *testing.T) {
+		m := orderedmap.NewOrderedMap()
+		assert.False(t, m.Has("foo"))
+	})
+
+	t.Run("ReturnsTrueIfKeyExists", func(t *testing.T) {
+		m := orderedmap.NewOrderedMap()
+		m.Set("foo", "bar")
+		assert.True(t, m.Has("foo"))
+	})
+
+	t.Run("KeyDoesNotExistAfterDelete", func(t *testing.T) {
+		m := orderedmap.NewOrderedMap()
+		m.Set("foo", "bar")
+		m.Delete("foo")
+		assert.False(t, m.Has("foo"))
+	})
+}
+
 func benchmarkMap_Set(multiplier int) func(b *testing.B) {
 	return func(b *testing.B) {
 		m := make(map[int]bool)
@@ -999,6 +1019,23 @@ func benchmarkBigOrderedMapString_Iterate() func(b *testing.B) {
 
 func BenchmarkBigOrderedMapString_Iterate(b *testing.B) {
 	benchmarkBigOrderedMapString_Iterate()(b)
+}
+
+func benchmarkOrderedMap_Has(multiplier int) func(b *testing.B) {
+	m := orderedmap.NewOrderedMap()
+	for i := 0; i < 1000*multiplier; i++ {
+		m.Set(i, true)
+	}
+
+	return func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			m.Has(i % 1000 * multiplier)
+		}
+	}
+}
+
+func BenchmarkOrderedMap_Has(b *testing.B) {
+	benchmarkOrderedMap_Has(1)(b)
 }
 
 func BenchmarkAll(b *testing.B) {

--- a/orderedmap_test.go
+++ b/orderedmap_test.go
@@ -548,6 +548,40 @@ func BenchmarkOrderedMap_Iterate(b *testing.B) {
 	benchmarkOrderedMap_Iterate(1)(b)
 }
 
+func benchmarkOrderedMap_Has(multiplier int) func(b *testing.B) {
+	m := orderedmap.NewOrderedMap()
+	for i := 0; i < 1000*multiplier; i++ {
+		m.Set(i, true)
+	}
+
+	return func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			m.Has(i % 1000 * multiplier)
+		}
+	}
+}
+
+func BenchmarkOrderedMap_Has(b *testing.B) {
+	benchmarkOrderedMap_Has(1)(b)
+}
+
+func benchmarkMap_Has(multiplier int) func(b *testing.B) {
+	m := make(map[int]bool)
+	for i := 0; i < 1000*multiplier; i++ {
+		m[i] = true
+	}
+
+	return func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			_, _ = m[i%1000*multiplier]
+		}
+	}
+}
+
+func BenchmarkMap_Has(b *testing.B) {
+	benchmarkMap_Has(1)(b)
+}
+
 func benchmarkOrderedMap_Keys(multiplier int) func(b *testing.B) {
 	m := orderedmap.NewOrderedMap()
 	for i := 0; i < 1000*multiplier; i++ {
@@ -1021,23 +1055,6 @@ func BenchmarkBigOrderedMapString_Iterate(b *testing.B) {
 	benchmarkBigOrderedMapString_Iterate()(b)
 }
 
-func benchmarkOrderedMap_Has(multiplier int) func(b *testing.B) {
-	m := orderedmap.NewOrderedMap()
-	for i := 0; i < 1000*multiplier; i++ {
-		m.Set(i, true)
-	}
-
-	return func(b *testing.B) {
-		for i := 0; i < b.N; i++ {
-			m.Has(i % 1000 * multiplier)
-		}
-	}
-}
-
-func BenchmarkOrderedMap_Has(b *testing.B) {
-	benchmarkOrderedMap_Has(1)(b)
-}
-
 func BenchmarkAll(b *testing.B) {
 	b.Run("BenchmarkOrderedMap_Keys", BenchmarkOrderedMap_Keys)
 
@@ -1050,6 +1067,8 @@ func BenchmarkAll(b *testing.B) {
 	b.Run("BenchmarkMap_Delete", BenchmarkMap_Delete)
 	b.Run("BenchmarkOrderedMap_Iterate", BenchmarkOrderedMap_Iterate)
 	b.Run("BenchmarkMap_Iterate", BenchmarkMap_Iterate)
+	b.Run("BenchmarkOrderedMap_Has", BenchmarkOrderedMap_Has)
+	b.Run("BenchmarkMap_Has", BenchmarkMap_Has)
 
 	b.Run("BenchmarkBigMap_Set", BenchmarkBigMap_Set)
 	b.Run("BenchmarkBigOrderedMap_Set", BenchmarkBigOrderedMap_Set)
@@ -1068,7 +1087,6 @@ func BenchmarkAll(b *testing.B) {
 	b.Run("BenchmarkMapString_Delete", BenchmarkMapString_Delete)
 	b.Run("BenchmarkOrderedMapString_Iterate", BenchmarkOrderedMapString_Iterate)
 	b.Run("BenchmarkMapString_Iterate", BenchmarkMapString_Iterate)
-	b.Run("BenchmarkOrderedMap_Has", BenchmarkOrderedMap_Has)
 
 	b.Run("BenchmarkBigMapString_Set", BenchmarkBigMapString_Set)
 	b.Run("BenchmarkBigOrderedMapString_Set", BenchmarkBigOrderedMapString_Set)

--- a/orderedmap_test.go
+++ b/orderedmap_test.go
@@ -544,8 +544,21 @@ func benchmarkOrderedMap_Iterate(multiplier int) func(b *testing.B) {
 	}
 }
 
-func BenchmarkOrderedMap_Iterate(b *testing.B) {
-	benchmarkOrderedMap_Iterate(1)(b)
+func benchmarkMap_Has(multiplier int) func(b *testing.B) {
+	m := make(map[int]bool)
+	for i := 0; i < 1000*multiplier; i++ {
+		m[i] = true
+	}
+
+	return func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			_ = m[i%1000*multiplier]
+		}
+	}
+}
+
+func BenchmarkMap_Has(b *testing.B) {
+	benchmarkMap_Has(1)(b)
 }
 
 func benchmarkOrderedMap_Has(multiplier int) func(b *testing.B) {
@@ -565,21 +578,8 @@ func BenchmarkOrderedMap_Has(b *testing.B) {
 	benchmarkOrderedMap_Has(1)(b)
 }
 
-func benchmarkMap_Has(multiplier int) func(b *testing.B) {
-	m := make(map[int]bool)
-	for i := 0; i < 1000*multiplier; i++ {
-		m[i] = true
-	}
-
-	return func(b *testing.B) {
-		for i := 0; i < b.N; i++ {
-			_, _ = m[i%1000*multiplier]
-		}
-	}
-}
-
-func BenchmarkMap_Has(b *testing.B) {
-	benchmarkMap_Has(1)(b)
+func BenchmarkOrderedMap_Iterate(b *testing.B) {
+	benchmarkOrderedMap_Iterate(1)(b)
 }
 
 func benchmarkOrderedMap_Keys(multiplier int) func(b *testing.B) {
@@ -750,6 +750,42 @@ func benchmarkOrderedMapString_Iterate(multiplier int) func(b *testing.B) {
 
 func BenchmarkOrderedMapString_Iterate(b *testing.B) {
 	benchmarkOrderedMapString_Iterate(1)(b)
+}
+
+func benchmarkMapString_Has(multiplier int) func(b *testing.B) {
+	m := make(map[string]bool)
+	a := "12345678"
+	for i := 0; i < 1000*multiplier; i++ {
+		m[a+strconv.Itoa(i)] = true
+	}
+
+	return func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			_ = m[a+strconv.Itoa(i%1000*multiplier)]
+		}
+	}
+}
+
+func BenchmarkMapString_Has(b *testing.B) {
+	benchmarkMapString_Has(1)(b)
+}
+
+func benchmarkOrderedMapString_Has(multiplier int) func(b *testing.B) {
+	m := orderedmap.NewOrderedMap()
+	a := "12345678"
+	for i := 0; i < 1000*multiplier; i++ {
+		m.Set(a+strconv.Itoa(i), true)
+	}
+
+	return func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			m.Has(a + strconv.Itoa(i%1000*multiplier))
+		}
+	}
+}
+
+func BenchmarkOrderedMapString_Has(b *testing.B) {
+	benchmarkOrderedMapString_Has(1)(b)
 }
 
 func BenchmarkOrderedMap_Keys(b *testing.B) {
@@ -936,6 +972,44 @@ func benchmarkBigMapString_Set() func(b *testing.B) {
 	}
 }
 
+func benchmarkBigMap_Has() func(b *testing.B) {
+	m := make(map[int]bool)
+	for i := 0; i < 10000000; i++ {
+		m[i] = true
+	}
+
+	return func(b *testing.B) {
+		for j := 0; j < b.N; j++ {
+			for i := 0; i < 10000000; i++ {
+				_ = m[i]
+			}
+		}
+	}
+}
+
+func BenchmarkBigMap_Has(b *testing.B) {
+	benchmarkBigMap_Has()(b)
+}
+
+func benchmarkBigOrderedMap_Has() func(b *testing.B) {
+	m := orderedmap.NewOrderedMap()
+	for i := 0; i < 10000000; i++ {
+		m.Set(i, true)
+	}
+
+	return func(b *testing.B) {
+		for j := 0; j < b.N; j++ {
+			for i := 0; i < 10000000; i++ {
+				m.Has(i)
+			}
+		}
+	}
+}
+
+func BenchmarkBigOrderedMap_Has(b *testing.B) {
+	benchmarkBigOrderedMap_Has()(b)
+}
+
 func BenchmarkBigMapString_Set(b *testing.B) {
 	benchmarkBigMapString_Set()(b)
 }
@@ -1055,6 +1129,45 @@ func BenchmarkBigOrderedMapString_Iterate(b *testing.B) {
 	benchmarkBigOrderedMapString_Iterate()(b)
 }
 
+func benchmarkBigMapString_Has() func(b *testing.B) {
+	m := make(map[string]bool)
+	a := "12345678"
+	for i := 0; i < 10000000; i++ {
+		m[a+strconv.Itoa(i)] = true
+	}
+
+	return func(b *testing.B) {
+		for j := 0; j < b.N; j++ {
+			for i := 0; i < 10000000; i++ {
+				_ = m[a+strconv.Itoa(i)]
+			}
+		}
+	}
+}
+
+func BenchmarkBigMapString_Has(b *testing.B) {
+	benchmarkBigMapString_Has()(b)
+}
+
+func benchmarkBigOrderedMapString_Has() func(b *testing.B) {
+	m := orderedmap.NewOrderedMap()
+	for i := 0; i < 10000000; i++ {
+		m.Set(i, true)
+	}
+
+	return func(b *testing.B) {
+		for j := 0; j < b.N; j++ {
+			for i := 0; i < 10000000; i++ {
+				m.Has(i)
+			}
+		}
+	}
+}
+
+func BenchmarkBigOrderedMapString_Has(b *testing.B) {
+	benchmarkBigOrderedMapString_Has()(b)
+}
+
 func BenchmarkAll(b *testing.B) {
 	b.Run("BenchmarkOrderedMap_Keys", BenchmarkOrderedMap_Keys)
 
@@ -1077,6 +1190,8 @@ func BenchmarkAll(b *testing.B) {
 	b.Run("BenchmarkBigOrderedMap_GetElement", BenchmarkBigOrderedMap_GetElement)
 	b.Run("BenchmarkBigOrderedMap_Iterate", BenchmarkBigOrderedMap_Iterate)
 	b.Run("BenchmarkBigMap_Iterate", BenchmarkBigMap_Iterate)
+	b.Run("BenchmarkBigMap_Has", BenchmarkBigMap_Has)
+	b.Run("BenchmarkBigOrderedMap_Has", BenchmarkBigOrderedMap_Has)
 
 	b.Run("BenchmarkOrderedMapString_Set", BenchmarkOrderedMapString_Set)
 	b.Run("BenchmarkMapString_Set", BenchmarkMapString_Set)
@@ -1087,6 +1202,8 @@ func BenchmarkAll(b *testing.B) {
 	b.Run("BenchmarkMapString_Delete", BenchmarkMapString_Delete)
 	b.Run("BenchmarkOrderedMapString_Iterate", BenchmarkOrderedMapString_Iterate)
 	b.Run("BenchmarkMapString_Iterate", BenchmarkMapString_Iterate)
+	b.Run("BenchmarkMapString_Has", BenchmarkMapString_Has)
+	b.Run("BenchmarkOrderedMapString_Has", BenchmarkOrderedMapString_Has)
 
 	b.Run("BenchmarkBigMapString_Set", BenchmarkBigMapString_Set)
 	b.Run("BenchmarkBigOrderedMapString_Set", BenchmarkBigOrderedMapString_Set)
@@ -1095,4 +1212,6 @@ func BenchmarkAll(b *testing.B) {
 	b.Run("BenchmarkBigOrderedMapString_GetElement", BenchmarkBigOrderedMapString_GetElement)
 	b.Run("BenchmarkBigOrderedMapString_Iterate", BenchmarkBigOrderedMapString_Iterate)
 	b.Run("BenchmarkBigMapString_Iterate", BenchmarkBigMapString_Iterate)
+	b.Run("BenchmarkBigMapString_Has", BenchmarkBigMapString_Has)
+	b.Run("BenchmarkBigOrderedMapString_Has", BenchmarkBigOrderedMapString_Has)
 }

--- a/v2/orderedmap.go
+++ b/v2/orderedmap.go
@@ -138,3 +138,9 @@ func (m *OrderedMap[K, V]) Copy() *OrderedMap[K, V] {
 	}
 	return m2
 }
+
+// Has checks if a key exists in the map.
+func (m *OrderedMap[K, V]) Has(key K) bool {
+	_, exists := m.kv[key]
+	return exists
+}

--- a/v2/orderedmap_test.go
+++ b/v2/orderedmap_test.go
@@ -351,6 +351,26 @@ func TestIterations(t *testing.T) {
 	})
 }
 
+func TestOrderedMap_Has(t *testing.T) {
+	t.Run("ReturnsFalseIfKeyDoesNotExist", func(t *testing.T) {
+		m := orderedmap.NewOrderedMap[string, string]()
+		assert.False(t, m.Has("foo"))
+	})
+
+	t.Run("ReturnsTrueIfKeyExists", func(t *testing.T) {
+		m := orderedmap.NewOrderedMap[string, string]()
+		m.Set("foo", "bar")
+		assert.True(t, m.Has("foo"))
+	})
+
+	t.Run("KeyDoesNotExistAfterDelete", func(t *testing.T) {
+		m := orderedmap.NewOrderedMap[string, string]()
+		m.Set("foo", "bar")
+		m.Delete("foo")
+		assert.False(t, m.Has("foo"))
+	})
+}
+
 func benchmarkMap_Set(multiplier int) func(b *testing.B) {
 	return func(b *testing.B) {
 		m := make(map[int]bool)
@@ -970,6 +990,19 @@ func BenchmarkBigOrderedMapString_Iterate(b *testing.B) {
 	benchmarkBigOrderedMapString_Iterate()(b)
 }
 
+func benchmarkOrderedMap_Has(multiplier int) func(b *testing.B) {
+	return func(b *testing.B) {
+		m := orderedmap.NewOrderedMap[int, bool]()
+		for i := 0; i < b.N*multiplier; i++ {
+			m.Has(i)
+		}
+	}
+}
+
+func BenchmarkOrderedMap_Has(b *testing.B) {
+	benchmarkOrderedMap_Has(1)(b)
+}
+
 func BenchmarkAll(b *testing.B) {
 	b.Run("BenchmarkOrderedMap_Keys", BenchmarkOrderedMap_Keys)
 
@@ -1013,4 +1046,5 @@ func BenchmarkAll(b *testing.B) {
 	b.Run("BenchmarkBigOrderedMapString_Iterate",
 		BenchmarkBigOrderedMapString_Iterate)
 	b.Run("BenchmarkBigMapString_Iterate", BenchmarkBigMapString_Iterate)
+	b.Run("BenchmarkOrderedMap_Has", BenchmarkOrderedMap_Has)
 }

--- a/v2/orderedmap_test.go
+++ b/v2/orderedmap_test.go
@@ -542,6 +542,23 @@ func BenchmarkOrderedMap_Iterate(b *testing.B) {
 	benchmarkOrderedMap_Iterate(1)(b)
 }
 
+func benchmarkMap_Has(multiplier int) func(b *testing.B) {
+	m := make(map[int]bool)
+	for i := 0; i < 1000*multiplier; i++ {
+		m[i] = true
+	}
+
+	return func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			_ = m[i%1000*multiplier]
+		}
+	}
+}
+
+func BenchmarkMap_Has(b *testing.B) {
+	benchmarkMap_Has(1)(b)
+}
+
 func benchmarkOrderedMap_Has(multiplier int) func(b *testing.B) {
 	m := orderedmap.NewOrderedMap[int, bool]()
 	for i := 0; i < 1000*multiplier; i++ {
@@ -556,23 +573,6 @@ func benchmarkOrderedMap_Has(multiplier int) func(b *testing.B) {
 
 func BenchmarkOrderedMap_Has(b *testing.B) {
 	benchmarkOrderedMap_Has(1)(b)
-}
-
-func benchmarkMap_Has(multiplier int) func(b *testing.B) {
-	m := make(map[int]bool)
-	for i := 0; i < 1000*multiplier; i++ {
-		m[i] = true
-	}
-
-	return func(b *testing.B) {
-		for i := 0; i < b.N; i++ {
-			_, _ = m[i%1000*multiplier]
-		}
-	}
-}
-
-func BenchmarkMap_Has(b *testing.B) {
-	benchmarkMap_Has(1)(b)
 }
 
 func benchmarkOrderedMap_Keys(multiplier int) func(b *testing.B) {
@@ -745,6 +745,40 @@ func BenchmarkOrderedMapString_Iterate(b *testing.B) {
 	benchmarkOrderedMapString_Iterate(1)(b)
 }
 
+func benchmarkMapString_Has(multiplier int) func(b *testing.B) {
+	m := make(map[string]bool)
+	a := "12345678"
+	for i := 0; i < 1000*multiplier; i++ {
+		m[a+strconv.Itoa(i)] = true
+	}
+	return func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			_ = m[a+strconv.Itoa(i%1000*multiplier)]
+		}
+	}
+}
+
+func BenchmarkMapString_Has(b *testing.B) {
+	benchmarkMapString_Has(1)(b)
+}
+
+func benchmarkOrderedMapString_Has(multiplier int) func(b *testing.B) {
+	m := orderedmap.NewOrderedMap[string, bool]()
+	a := "12345678"
+	for i := 0; i < 1000*multiplier; i++ {
+		m.Set(a+strconv.Itoa(i), true)
+	}
+	return func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			m.Has(a + strconv.Itoa(i%1000*multiplier))
+		}
+	}
+}
+
+func BenchmarkOrderedMapString_Has(b *testing.B) {
+	benchmarkOrderedMapString_Has(1)(b)
+}
+
 func BenchmarkOrderedMap_Keys(b *testing.B) {
 	benchmarkOrderedMap_Keys(1)(b)
 }
@@ -904,6 +938,42 @@ func benchmarkBigMapString_Set() func(b *testing.B) {
 	}
 }
 
+func benchmarkBigMap_Has() func(b *testing.B) {
+	m := make(map[int]bool)
+	for i := 0; i < 10000000; i++ {
+		m[i] = true
+	}
+	return func(b *testing.B) {
+		for j := 0; j < b.N; j++ {
+			for i := 0; i < 10000000; i++ {
+				_ = m[i]
+			}
+		}
+	}
+}
+
+func BenchmarkBigMap_Has(b *testing.B) {
+	benchmarkBigMap_Has()(b)
+}
+
+func benchmarkBigOrderedMap_Has() func(b *testing.B) {
+	m := orderedmap.NewOrderedMap[int, bool]()
+	for i := 0; i < 10000000; i++ {
+		m.Set(i, true)
+	}
+	return func(b *testing.B) {
+		for j := 0; j < b.N; j++ {
+			for i := 0; i < 10000000; i++ {
+				m.Has(i)
+			}
+		}
+	}
+}
+
+func BenchmarkBigOrderedMap_Has(b *testing.B) {
+	benchmarkBigOrderedMap_Has()(b)
+}
+
 func BenchmarkBigMapString_Set(b *testing.B) {
 	benchmarkBigMapString_Set()(b)
 }
@@ -1023,6 +1093,44 @@ func BenchmarkBigOrderedMapString_Iterate(b *testing.B) {
 	benchmarkBigOrderedMapString_Iterate()(b)
 }
 
+func benchmarkBigMapString_Has() func(b *testing.B) {
+	m := make(map[string]bool)
+	a := "12345678"
+	for i := 0; i < 10000000; i++ {
+		m[a+strconv.Itoa(i)] = true
+	}
+	return func(b *testing.B) {
+		for j := 0; j < b.N; j++ {
+			for i := 0; i < 10000000; i++ {
+				_ = m[a+strconv.Itoa(i)]
+			}
+		}
+	}
+}
+
+func BenchmarkBigMapString_Has(b *testing.B) {
+	benchmarkBigMapString_Has()(b)
+}
+
+func benchmarkBigOrderedMapString_Has() func(b *testing.B) {
+	m := orderedmap.NewOrderedMap[string, bool]()
+	a := "12345678"
+	for i := 0; i < 10000000; i++ {
+		m.Set(a+strconv.Itoa(i), true)
+	}
+	return func(b *testing.B) {
+		for j := 0; j < b.N; j++ {
+			for i := 0; i < 10000000; i++ {
+				m.Has(a + strconv.Itoa(i))
+			}
+		}
+	}
+}
+
+func BenchmarkBigOrderedMapString_Has(b *testing.B) {
+	benchmarkBigOrderedMapString_Has()(b)
+}
+
 func BenchmarkAll(b *testing.B) {
 	b.Run("BenchmarkOrderedMap_Keys", BenchmarkOrderedMap_Keys)
 
@@ -1046,6 +1154,8 @@ func BenchmarkAll(b *testing.B) {
 		BenchmarkBigOrderedMap_GetElement)
 	b.Run("BenchmarkBigOrderedMap_Iterate", BenchmarkBigOrderedMap_Iterate)
 	b.Run("BenchmarkBigMap_Iterate", BenchmarkBigMap_Iterate)
+	b.Run("BenchmarkBigMap_Has", BenchmarkBigMap_Has)
+	b.Run("BenchmarkBigOrderedMap_Has", BenchmarkBigOrderedMap_Has)
 
 	b.Run("BenchmarkOrderedMapString_Set", BenchmarkOrderedMapString_Set)
 	b.Run("BenchmarkMapString_Set", BenchmarkMapString_Set)
@@ -1058,6 +1168,8 @@ func BenchmarkAll(b *testing.B) {
 	b.Run("BenchmarkOrderedMapString_Iterate",
 		BenchmarkOrderedMapString_Iterate)
 	b.Run("BenchmarkMapString_Iterate", BenchmarkMapString_Iterate)
+	b.Run("BenchmarkMapString_Has", BenchmarkMapString_Has)
+	b.Run("BenchmarkOrderedMapString_Has", BenchmarkOrderedMapString_Has)
 
 	b.Run("BenchmarkBigMapString_Set", BenchmarkBigMapString_Set)
 	b.Run("BenchmarkBigOrderedMapString_Set", BenchmarkBigOrderedMapString_Set)
@@ -1068,4 +1180,6 @@ func BenchmarkAll(b *testing.B) {
 	b.Run("BenchmarkBigOrderedMapString_Iterate",
 		BenchmarkBigOrderedMapString_Iterate)
 	b.Run("BenchmarkBigMapString_Iterate", BenchmarkBigMapString_Iterate)
+	b.Run("BenchmarkBigMapString_Has", BenchmarkBigMapString_Has)
+	b.Run("BenchmarkBigOrderedMapString_Has", BenchmarkBigOrderedMapString_Has)
 }

--- a/v2/orderedmap_test.go
+++ b/v2/orderedmap_test.go
@@ -542,6 +542,39 @@ func BenchmarkOrderedMap_Iterate(b *testing.B) {
 	benchmarkOrderedMap_Iterate(1)(b)
 }
 
+func benchmarkOrderedMap_Has(multiplier int) func(b *testing.B) {
+	m := orderedmap.NewOrderedMap[int, bool]()
+	for i := 0; i < 1000*multiplier; i++ {
+		m.Set(i, true)
+	}
+	return func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			m.Has(i % 1000 * multiplier)
+		}
+	}
+}
+
+func BenchmarkOrderedMap_Has(b *testing.B) {
+	benchmarkOrderedMap_Has(1)(b)
+}
+
+func benchmarkMap_Has(multiplier int) func(b *testing.B) {
+	m := make(map[int]bool)
+	for i := 0; i < 1000*multiplier; i++ {
+		m[i] = true
+	}
+
+	return func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			_, _ = m[i%1000*multiplier]
+		}
+	}
+}
+
+func BenchmarkMap_Has(b *testing.B) {
+	benchmarkMap_Has(1)(b)
+}
+
 func benchmarkOrderedMap_Keys(multiplier int) func(b *testing.B) {
 	m := orderedmap.NewOrderedMap[int, bool]()
 	for i := 0; i < 1000*multiplier; i++ {
@@ -990,22 +1023,6 @@ func BenchmarkBigOrderedMapString_Iterate(b *testing.B) {
 	benchmarkBigOrderedMapString_Iterate()(b)
 }
 
-func benchmarkOrderedMap_Has(multiplier int) func(b *testing.B) {
-	m := orderedmap.NewOrderedMap[int, bool]()
-	for i := 0; i < 1000*multiplier; i++ {
-		m.Set(i, true)
-	}
-	return func(b *testing.B) {
-		for i := 0; i < b.N; i++ {
-			m.Has(i % 1000 * multiplier)
-		}
-	}
-}
-
-func BenchmarkOrderedMap_Has(b *testing.B) {
-	benchmarkOrderedMap_Has(1)(b)
-}
-
 func BenchmarkAll(b *testing.B) {
 	b.Run("BenchmarkOrderedMap_Keys", BenchmarkOrderedMap_Keys)
 
@@ -1018,6 +1035,8 @@ func BenchmarkAll(b *testing.B) {
 	b.Run("BenchmarkMap_Delete", BenchmarkMap_Delete)
 	b.Run("BenchmarkOrderedMap_Iterate", BenchmarkOrderedMap_Iterate)
 	b.Run("BenchmarkMap_Iterate", BenchmarkMap_Iterate)
+	b.Run("BenchmarkOrderedMap_Has", BenchmarkOrderedMap_Has)
+	b.Run("BenchmarkMap_Has", BenchmarkMap_Has)
 
 	b.Run("BenchmarkBigMap_Set", BenchmarkBigMap_Set)
 	b.Run("BenchmarkBigOrderedMap_Set", BenchmarkBigOrderedMap_Set)
@@ -1049,5 +1068,4 @@ func BenchmarkAll(b *testing.B) {
 	b.Run("BenchmarkBigOrderedMapString_Iterate",
 		BenchmarkBigOrderedMapString_Iterate)
 	b.Run("BenchmarkBigMapString_Iterate", BenchmarkBigMapString_Iterate)
-	b.Run("BenchmarkOrderedMap_Has", BenchmarkOrderedMap_Has)
 }

--- a/v2/orderedmap_test.go
+++ b/v2/orderedmap_test.go
@@ -991,10 +991,13 @@ func BenchmarkBigOrderedMapString_Iterate(b *testing.B) {
 }
 
 func benchmarkOrderedMap_Has(multiplier int) func(b *testing.B) {
+	m := orderedmap.NewOrderedMap[int, bool]()
+	for i := 0; i < 1000*multiplier; i++ {
+		m.Set(i, true)
+	}
 	return func(b *testing.B) {
-		m := orderedmap.NewOrderedMap[int, bool]()
-		for i := 0; i < b.N*multiplier; i++ {
-			m.Has(i)
+		for i := 0; i < b.N; i++ {
+			m.Has(i % 1000 * multiplier)
 		}
 	}
 }

--- a/v3/orderedmap.go
+++ b/v3/orderedmap.go
@@ -179,3 +179,9 @@ func (m *OrderedMap[K, V]) Copy() *OrderedMap[K, V] {
 	}
 	return m2
 }
+
+// Has checks if a key exists in the map.
+func (m *OrderedMap[K, V]) Has(key K) bool {
+	_, exists := m.kv[key]
+	return exists
+}

--- a/v3/orderedmap_test.go
+++ b/v3/orderedmap_test.go
@@ -573,6 +573,39 @@ func BenchmarkOrderedMap_Iterate(b *testing.B) {
 	benchmarkOrderedMap_Iterate(1)(b)
 }
 
+func benchmarkOrderedMap_Has(multiplier int) func(b *testing.B) {
+	m := orderedmap.NewOrderedMap[int, bool]()
+	for i := 0; i < 1000*multiplier; i++ {
+		m.Set(i, true)
+	}
+	return func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			m.Has(i % 1000 * multiplier)
+		}
+	}
+}
+
+func BenchmarkOrderedMap_Has(b *testing.B) {
+	benchmarkOrderedMap_Has(1)(b)
+}
+
+func benchmarkMap_Has(multiplier int) func(b *testing.B) {
+	m := make(map[int]bool)
+	for i := 0; i < 1000*multiplier; i++ {
+		m[i] = true
+	}
+
+	return func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			_, _ = m[i%1000*multiplier]
+		}
+	}
+}
+
+func BenchmarkMap_Has(b *testing.B) {
+	benchmarkMap_Has(1)(b)
+}
+
 func benchmarkMapString_Set(multiplier int) func(b *testing.B) {
 	return func(b *testing.B) {
 		m := make(map[string]bool)
@@ -1007,22 +1040,6 @@ func BenchmarkBigOrderedMapString_Iterate(b *testing.B) {
 	benchmarkBigOrderedMapString_Iterate()(b)
 }
 
-func benchmarkOrderedMap_Has(multiplier int) func(b *testing.B) {
-	m := orderedmap.NewOrderedMap[int, bool]()
-	for i := 0; i < 1000*multiplier; i++ {
-		m.Set(i, true)
-	}
-	return func(b *testing.B) {
-		for i := 0; i < b.N; i++ {
-			m.Has(i % 1000 * multiplier)
-		}
-	}
-}
-
-func BenchmarkOrderedMap_Has(b *testing.B) {
-	benchmarkOrderedMap_Has(1)(b)
-}
-
 func BenchmarkAll(b *testing.B) {
 	b.Run("BenchmarkOrderedMap_Set", BenchmarkOrderedMap_Set)
 	b.Run("BenchmarkMap_Set", BenchmarkMap_Set)
@@ -1033,6 +1050,8 @@ func BenchmarkAll(b *testing.B) {
 	b.Run("BenchmarkMap_Delete", BenchmarkMap_Delete)
 	b.Run("BenchmarkOrderedMap_Iterate", BenchmarkOrderedMap_Iterate)
 	b.Run("BenchmarkMap_Iterate", BenchmarkMap_Iterate)
+	b.Run("BenchmarkOrderedMap_Has", BenchmarkOrderedMap_Has)
+	b.Run("BenchmarkMap_Has", BenchmarkMap_Has)
 
 	b.Run("BenchmarkBigMap_Set", BenchmarkBigMap_Set)
 	b.Run("BenchmarkBigOrderedMap_Set", BenchmarkBigOrderedMap_Set)
@@ -1064,5 +1083,4 @@ func BenchmarkAll(b *testing.B) {
 	b.Run("BenchmarkBigOrderedMapString_Iterate",
 		BenchmarkBigOrderedMapString_Iterate)
 	b.Run("BenchmarkBigMapString_Iterate", BenchmarkBigMapString_Iterate)
-	b.Run("BenchmarkOrderedMap_Has", BenchmarkOrderedMap_Has)
 }

--- a/v3/orderedmap_test.go
+++ b/v3/orderedmap_test.go
@@ -381,6 +381,26 @@ func TestIterators(t *testing.T) {
 	})
 }
 
+func TestOrderedMap_Has(t *testing.T) {
+	t.Run("ReturnsFalseIfKeyDoesNotExist", func(t *testing.T) {
+		m := orderedmap.NewOrderedMap[string, string]()
+		assert.False(t, m.Has("foo"))
+	})
+
+	t.Run("ReturnsTrueIfKeyExists", func(t *testing.T) {
+		m := orderedmap.NewOrderedMap[string, string]()
+		m.Set("foo", "bar")
+		assert.True(t, m.Has("foo"))
+	})
+
+	t.Run("KeyDoesNotExistAfterDelete", func(t *testing.T) {
+		m := orderedmap.NewOrderedMap[string, string]()
+		m.Set("foo", "bar")
+		m.Delete("foo")
+		assert.False(t, m.Has("foo"))
+	})
+}
+
 func benchmarkMap_Set(multiplier int) func(b *testing.B) {
 	return func(b *testing.B) {
 		m := make(map[int]bool)
@@ -987,6 +1007,22 @@ func BenchmarkBigOrderedMapString_Iterate(b *testing.B) {
 	benchmarkBigOrderedMapString_Iterate()(b)
 }
 
+func benchmarkOrderedMap_Has(multiplier int) func(b *testing.B) {
+	m := orderedmap.NewOrderedMap[int, bool]()
+	for i := 0; i < 1000*multiplier; i++ {
+		m.Set(i, true)
+	}
+	return func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			m.Has(i % 1000 * multiplier)
+		}
+	}
+}
+
+func BenchmarkOrderedMap_Has(b *testing.B) {
+	benchmarkOrderedMap_Has(1)(b)
+}
+
 func BenchmarkAll(b *testing.B) {
 	b.Run("BenchmarkOrderedMap_Set", BenchmarkOrderedMap_Set)
 	b.Run("BenchmarkMap_Set", BenchmarkMap_Set)
@@ -1028,4 +1064,5 @@ func BenchmarkAll(b *testing.B) {
 	b.Run("BenchmarkBigOrderedMapString_Iterate",
 		BenchmarkBigOrderedMapString_Iterate)
 	b.Run("BenchmarkBigMapString_Iterate", BenchmarkBigMapString_Iterate)
+	b.Run("BenchmarkOrderedMap_Has", BenchmarkOrderedMap_Has)
 }

--- a/v3/orderedmap_test.go
+++ b/v3/orderedmap_test.go
@@ -573,6 +573,23 @@ func BenchmarkOrderedMap_Iterate(b *testing.B) {
 	benchmarkOrderedMap_Iterate(1)(b)
 }
 
+func benchmarkMap_Has(multiplier int) func(b *testing.B) {
+	m := make(map[int]bool)
+	for i := 0; i < 1000*multiplier; i++ {
+		m[i] = true
+	}
+
+	return func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			_ = m[i%1000*multiplier]
+		}
+	}
+}
+
+func BenchmarkMap_Has(b *testing.B) {
+	benchmarkMap_Has(1)(b)
+}
+
 func benchmarkOrderedMap_Has(multiplier int) func(b *testing.B) {
 	m := orderedmap.NewOrderedMap[int, bool]()
 	for i := 0; i < 1000*multiplier; i++ {
@@ -587,23 +604,6 @@ func benchmarkOrderedMap_Has(multiplier int) func(b *testing.B) {
 
 func BenchmarkOrderedMap_Has(b *testing.B) {
 	benchmarkOrderedMap_Has(1)(b)
-}
-
-func benchmarkMap_Has(multiplier int) func(b *testing.B) {
-	m := make(map[int]bool)
-	for i := 0; i < 1000*multiplier; i++ {
-		m[i] = true
-	}
-
-	return func(b *testing.B) {
-		for i := 0; i < b.N; i++ {
-			_, _ = m[i%1000*multiplier]
-		}
-	}
-}
-
-func BenchmarkMap_Has(b *testing.B) {
-	benchmarkMap_Has(1)(b)
 }
 
 func benchmarkMapString_Set(multiplier int) func(b *testing.B) {
@@ -764,6 +764,40 @@ func BenchmarkOrderedMapString_Iterate(b *testing.B) {
 	benchmarkOrderedMapString_Iterate(1)(b)
 }
 
+func benchmarkMapString_Has(multiplier int) func(b *testing.B) {
+	m := make(map[string]bool)
+	a := "12345678"
+	for i := 0; i < 1000*multiplier; i++ {
+		m[a+strconv.Itoa(i)] = true
+	}
+	return func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			_ = m[a+strconv.Itoa(i%1000*multiplier)]
+		}
+	}
+}
+
+func BenchmarkMapString_Has(b *testing.B) {
+	benchmarkMapString_Has(1)(b)
+}
+
+func benchmarkOrderedMapString_Has(multiplier int) func(b *testing.B) {
+	m := orderedmap.NewOrderedMap[string, bool]()
+	a := "12345678"
+	for i := 0; i < 1000*multiplier; i++ {
+		m.Set(a+strconv.Itoa(i), true)
+	}
+	return func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			m.Has(a + strconv.Itoa(i%1000*multiplier))
+		}
+	}
+}
+
+func BenchmarkOrderedMapString_Has(b *testing.B) {
+	benchmarkOrderedMapString_Has(1)(b)
+}
+
 func nothing(v interface{}) {
 	v = false
 }
@@ -920,6 +954,42 @@ func benchmarkBigMapString_Set() func(b *testing.B) {
 	}
 }
 
+func benchmarkBigMap_Has() func(b *testing.B) {
+	m := make(map[int]bool)
+	for i := 0; i < 10000000; i++ {
+		m[i] = true
+	}
+	return func(b *testing.B) {
+		for j := 0; j < b.N; j++ {
+			for i := 0; i < 10000000; i++ {
+				_ = m[i]
+			}
+		}
+	}
+}
+
+func BenchmarkBigMap_Has(b *testing.B) {
+	benchmarkBigMap_Has()(b)
+}
+
+func benchmarkBigOrderedMap_Has() func(b *testing.B) {
+	m := orderedmap.NewOrderedMap[int, bool]()
+	for i := 0; i < 10000000; i++ {
+		m.Set(i, true)
+	}
+	return func(b *testing.B) {
+		for j := 0; j < b.N; j++ {
+			for i := 0; i < 10000000; i++ {
+				m.Has(i)
+			}
+		}
+	}
+}
+
+func BenchmarkBigOrderedMap_Has(b *testing.B) {
+	benchmarkBigOrderedMap_Has()(b)
+}
+
 func BenchmarkBigMapString_Set(b *testing.B) {
 	benchmarkBigMapString_Set()(b)
 }
@@ -1040,6 +1110,44 @@ func BenchmarkBigOrderedMapString_Iterate(b *testing.B) {
 	benchmarkBigOrderedMapString_Iterate()(b)
 }
 
+func benchmarkBigMapString_Has() func(b *testing.B) {
+	m := make(map[string]bool)
+	a := "12345678"
+	for i := 0; i < 10000000; i++ {
+		m[a+strconv.Itoa(i)] = true
+	}
+	return func(b *testing.B) {
+		for j := 0; j < b.N; j++ {
+			for i := 0; i < 10000000; i++ {
+				_ = m[a+strconv.Itoa(i)]
+			}
+		}
+	}
+}
+
+func BenchmarkBigMapString_Has(b *testing.B) {
+	benchmarkBigMapString_Has()(b)
+}
+
+func benchmarkBigOrderedMapString_Has() func(b *testing.B) {
+	m := orderedmap.NewOrderedMap[string, bool]()
+	a := "12345678"
+	for i := 0; i < 10000000; i++ {
+		m.Set(a+strconv.Itoa(i), true)
+	}
+	return func(b *testing.B) {
+		for j := 0; j < b.N; j++ {
+			for i := 0; i < 10000000; i++ {
+				m.Has(a + strconv.Itoa(i))
+			}
+		}
+	}
+}
+
+func BenchmarkBigOrderedMapString_Has(b *testing.B) {
+	benchmarkBigOrderedMapString_Has()(b)
+}
+
 func BenchmarkAll(b *testing.B) {
 	b.Run("BenchmarkOrderedMap_Set", BenchmarkOrderedMap_Set)
 	b.Run("BenchmarkMap_Set", BenchmarkMap_Set)
@@ -1061,6 +1169,8 @@ func BenchmarkAll(b *testing.B) {
 		BenchmarkBigOrderedMap_GetElement)
 	b.Run("BenchmarkBigOrderedMap_Iterate", BenchmarkBigOrderedMap_Iterate)
 	b.Run("BenchmarkBigMap_Iterate", BenchmarkBigMap_Iterate)
+	b.Run("BenchmarkBigMap_Has", BenchmarkBigMap_Has)
+	b.Run("BenchmarkBigOrderedMap_Has", BenchmarkBigOrderedMap_Has)
 
 	b.Run("BenchmarkOrderedMapString_Set", BenchmarkOrderedMapString_Set)
 	b.Run("BenchmarkMapString_Set", BenchmarkMapString_Set)
@@ -1073,6 +1183,8 @@ func BenchmarkAll(b *testing.B) {
 	b.Run("BenchmarkOrderedMapString_Iterate",
 		BenchmarkOrderedMapString_Iterate)
 	b.Run("BenchmarkMapString_Iterate", BenchmarkMapString_Iterate)
+	b.Run("BenchmarkMapString_Has", BenchmarkMapString_Has)
+	b.Run("BenchmarkOrderedMapString_Has", BenchmarkOrderedMapString_Has)
 
 	b.Run("BenchmarkBigMapString_Set", BenchmarkBigMapString_Set)
 	b.Run("BenchmarkBigOrderedMapString_Set", BenchmarkBigOrderedMapString_Set)
@@ -1083,4 +1195,6 @@ func BenchmarkAll(b *testing.B) {
 	b.Run("BenchmarkBigOrderedMapString_Iterate",
 		BenchmarkBigOrderedMapString_Iterate)
 	b.Run("BenchmarkBigMapString_Iterate", BenchmarkBigMapString_Iterate)
+	b.Run("BenchmarkBigMapString_Has", BenchmarkBigMapString_Has)
+	b.Run("BenchmarkBigOrderedMapString_Has", BenchmarkBigOrderedMapString_Has)
 }


### PR DESCRIPTION
This pull request introduces a new `Has` method to the `OrderedMap` structure across versions and adds corresponding tests and benchmarks to ensure its functionality and performance.

### Usage:
#### for v1
```go
m := orderedMap.NewOrderedMap()
keyExists := m.Has(key)
```
#### for v2, v3
```go
m := orderedMap.NewOrderedMap[string, string]()
keyExists := m.Has(key)
```

### Tests:
Added tests for v1, v2, and v3

### Benchmarks:
Added benchmarks in v1, v2, and v3

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/orderedmap/54)
<!-- Reviewable:end -->
