### PR TITLE
Implement thread safe interface for the OrderedMap

### DIFF
--- a/v3/syncorderedmap.go
+++ b/v3/syncorderedmap.go
@@ -43,6 +43,13 @@ func (m *SyncOrderedMap[K, V]) GetOrDefault(key K, defaultValue V) V {
 	return m.OrderedMap.GetOrDefault(key, defaultValue)
 }
 
+func (m *SyncOrderedMap[K, V]) GetElement(key K) *Element[K, V] {
+	m.RLock()
+	defer m.RUnlock()
+
+	return m.OrderedMap.GetElement(key)
+}
+
 func (m *SyncOrderedMap[K, V]) Len() int {
 	m.RLock()
 	defer m.RUnlock()

--- a/v3/syncorderedmap.go
+++ b/v3/syncorderedmap.go
@@ -1,0 +1,8 @@
+package orderedmap
+
+import "sync"
+
+type SyncOrderedMap[K comparable, V any] struct {
+	OrderedMap[K, V]
+	sync.RWMutex
+}

--- a/v3/syncorderedmap.go
+++ b/v3/syncorderedmap.go
@@ -6,6 +6,15 @@ type SyncOrderedMap[K comparable, V any] struct {
 	OrderedMap[K, V]
 	sync.RWMutex
 }
+
+func NewSyncOrderedMap[K comparable, V any]() *SyncOrderedMap[K, V] {
+	return &SyncOrderedMap[K, V]{*NewOrderedMap[K, V](), sync.RWMutex{}}
+}
+
+func NewSyncOrderedMapWithCapacity[K comparable, V any](capacity int) *SyncOrderedMap[K, V] {
+	return &SyncOrderedMap[K, V]{*NewOrderedMapWithCapacity[K, V](capacity), sync.RWMutex{}}
+}
+
 func (m *SyncOrderedMap[K, V]) Get(key K) (value V, ok bool) {
 	m.RLock()
 	defer m.RUnlock()

--- a/v3/syncorderedmap.go
+++ b/v3/syncorderedmap.go
@@ -6,3 +6,58 @@ type SyncOrderedMap[K comparable, V any] struct {
 	OrderedMap[K, V]
 	sync.RWMutex
 }
+func (m *SyncOrderedMap[K, V]) Get(key K) (value V, ok bool) {
+	m.RLock()
+	defer m.RUnlock()
+
+	return m.OrderedMap.Get(key)
+}
+
+func (m *SyncOrderedMap[K, V]) Set(key K, value V) bool {
+	m.Lock()
+	defer m.Unlock()
+
+	return m.OrderedMap.Set(key, value)
+}
+
+func (m *SyncOrderedMap[K, V]) ReplaceKey(originalKey, newKey K) bool {
+	m.Lock()
+	defer m.Unlock()
+
+	return m.OrderedMap.ReplaceKey(originalKey, newKey)
+}
+
+func (m *SyncOrderedMap[K, V]) GetOrDefault(key K, defaultValue V) V {
+	m.RLock()
+	defer m.RUnlock()
+
+	return m.OrderedMap.GetOrDefault(key, defaultValue)
+}
+
+func (m *SyncOrderedMap[K, V]) Len() int {
+	m.RLock()
+	defer m.RUnlock()
+
+	return m.OrderedMap.Len()
+}
+
+func (m *SyncOrderedMap[K, V]) Delete(key K) (didDelete bool) {
+	m.Lock()
+	defer m.Unlock()
+
+	return m.OrderedMap.Delete(key)
+}
+
+func (m *SyncOrderedMap[K, V]) Copy() *OrderedMap[K, V] {
+	m.RLock()
+	defer m.RUnlock()
+
+	return m.OrderedMap.Copy()
+}
+
+func (m *SyncOrderedMap[K, V]) Has(key K) bool {
+	m.RLock()
+	defer m.RUnlock()
+
+	return m.OrderedMap.Has(key)
+}

--- a/v3/syncorderedmap_test.go
+++ b/v3/syncorderedmap_test.go
@@ -92,7 +92,9 @@ func TestRaceCondition(t *testing.T) {
 			key := rand.Intn(100)
 			e := m.GetElement(key)
 			if e != nil {
-				fmt.Println(e.Value)
+				m.RLock()
+				_ = e.Value
+				m.RUnlock()
 			}
 			wg.Done()
 		}()

--- a/v3/syncorderedmap_test.go
+++ b/v3/syncorderedmap_test.go
@@ -114,3 +114,34 @@ func TestRaceCondition(t *testing.T) {
 	fmt.Println("TestRaceCondition completed")
 	fmt.Printf("SyncOrderedMap eventually has %v elements\n", m.Len())
 }
+
+func TestSyncOrderedMapMutex(t *testing.T) {
+	m := orderedmap.NewSyncOrderedMap[int, string]()
+
+	for i := 0; i < 1000; i++ {
+		m.Set(i, fmt.Sprintf("value-%v", i))
+	}
+
+	stop := make(chan struct{})
+	go func() {
+		i := 0
+		for {
+			select {
+			case <-stop:
+				return
+
+			default:
+				m.Set(i, fmt.Sprintf("new-value-%v", i))
+				i++
+			}
+		}
+	}()
+
+	m.Lock()
+	for key := range m.Keys() {
+		m.OrderedMap.Get(key)
+	}
+	m.Unlock()
+
+	stop <- struct{}{}
+}

--- a/v3/syncorderedmap_test.go
+++ b/v3/syncorderedmap_test.go
@@ -86,6 +86,18 @@ func TestRaceCondition(t *testing.T) {
 		}()
 	}
 
+	var asyncGetElement = func() {
+		wg.Add(1)
+		go func() {
+			key := rand.Intn(100)
+			e := m.GetElement(key)
+			if e != nil {
+				fmt.Println(e.Value)
+			}
+			wg.Done()
+		}()
+	}
+
 	for i := 0; i < 10000; i++ {
 		asyncSet()
 		asyncGet()
@@ -95,6 +107,7 @@ func TestRaceCondition(t *testing.T) {
 		asyncReplaceKEy()
 		asyncGetOrDefault()
 		asyncCopy()
+		asyncGetElement()
 	}
 
 	wg.Wait()

--- a/v3/syncorderedmap_test.go
+++ b/v3/syncorderedmap_test.go
@@ -1,0 +1,103 @@
+package orderedmap_test
+
+import (
+	"fmt"
+	"math/rand"
+	"sync"
+	"testing"
+
+	"github.com/elliotchance/orderedmap/v3"
+)
+
+func TestRaceCondition(t *testing.T) {
+	m := orderedmap.NewSyncOrderedMap[int, int]()
+	wg := &sync.WaitGroup{}
+
+	var asyncGet = func() {
+		wg.Add(1)
+		go func() {
+			key := rand.Intn(100)
+			m.Get(key)
+			wg.Done()
+		}()
+	}
+
+	var asyncSet = func() {
+		wg.Add(1)
+		go func() {
+			key := rand.Intn(100)
+			value := rand.Intn(100)
+			m.Set(key, value)
+			wg.Done()
+		}()
+	}
+
+	var asyncDelete = func() {
+		wg.Add(1)
+		go func() {
+			key := rand.Intn(100)
+			m.Delete(key)
+			wg.Done()
+		}()
+	}
+
+	var asyncHas = func() {
+		wg.Add(1)
+		go func() {
+			key := rand.Intn(100)
+			m.Has(key)
+			wg.Done()
+		}()
+	}
+
+	var asyncReplaceKEy = func() {
+		wg.Add(1)
+		go func() {
+			key := rand.Intn(100)
+			newKey := rand.Intn(100)
+			m.ReplaceKey(key, newKey)
+			wg.Done()
+		}()
+	}
+
+	var asyncGetOrDefault = func() {
+		wg.Add(1)
+		go func() {
+			key := rand.Intn(100)
+			def := rand.Intn(100)
+			m.GetOrDefault(key, def)
+			wg.Done()
+		}()
+	}
+
+	var asyncLen = func() {
+		wg.Add(1)
+		go func() {
+			m.Len()
+			wg.Done()
+		}()
+	}
+
+	var asyncCopy = func() {
+		wg.Add(1)
+		go func() {
+			m.Copy()
+			wg.Done()
+		}()
+	}
+
+	for i := 0; i < 10000; i++ {
+		asyncSet()
+		asyncGet()
+		asyncDelete()
+		asyncHas()
+		asyncLen()
+		asyncReplaceKEy()
+		asyncGetOrDefault()
+		asyncCopy()
+	}
+
+	wg.Wait()
+	fmt.Println("TestRaceCondition completed")
+	fmt.Printf("SyncOrderedMap eventually has %v elements\n", m.Len())
+}


### PR DESCRIPTION
This PR add a struct `SyncOrderedMap` which is basically a Thread safe wrapped to `OrderedMap`
As mentioned in this comment: https://github.com/elliotchance/orderedmap/pull/62#issuecomment-3052861380

I understand implementing thread safe operation directly in the `OrderedMap` isn't what we want as it would add an extra complexity to scenarios where thread safe isn't required, adding another struct `SyncOrderedMap` give the consumer the choice to use or not the thread safe feature.

I assumed that methods such as `GetElement` and the iterators are not really compatible with thread safe given that it will provide access to the inner component of the `OrderedMap` which could then be used a non thread safe manner.
Example we could totally return a `*Element` safely but using this Element to read/write the key or the value would kind of "corrupt" the `SyncOrderedMap`

For the same reason I didn't support `NewOrderedMapWithElements` for `SyncOrderedMap`, however I think a method on `OrderedMap` or another constructor for `SyncOrderedMap` which would create a new `SyncOrderedMap` from an existing `OrderedMap` could be interesting, this would need to copy the value though, as we don't want values to be still accessible from a non thread safe `OrderedMap`.

Test:
I added a unit test verifying that the `SyncOrderedMap` is race condition free, not sure if it's enough for you?
I think we could reimplement some of the test for this new struct to make sure it doesn't introduce any regression?

Question:
Should I also put my changes on `v1` and `v2` given that it doesn't introduce any breaking chance?

@elliotchance 

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/orderedmap/63)
<!-- Reviewable:end -->
