### PR TITLE
fix: increase performance test tolerance to prevent flaky failures

### DIFF
--- a/orderedmap_test.go
+++ b/orderedmap_test.go
@@ -76,7 +76,7 @@ func TestGet(t *testing.T) {
 
 		assert.InDelta(t,
 			res1.NsPerOp(), res4.NsPerOp(),
-			0.5*float64(res1.NsPerOp()))
+			float64(res1.NsPerOp()))
 	})
 }
 
@@ -167,7 +167,7 @@ func TestLen(t *testing.T) {
 
 		assert.InDelta(t,
 			res1.NsPerOp(), res4.NsPerOp(),
-			0.5*float64(res1.NsPerOp()))
+			float64(res1.NsPerOp()))
 	})
 }
 
@@ -353,7 +353,7 @@ func TestGetElement(t *testing.T) {
 
 		assert.InDelta(t,
 			res1.NsPerOp(), res4.NsPerOp(),
-			0.5*float64(res1.NsPerOp()))
+			float64(res1.NsPerOp()))
 	})
 }
 


### PR DESCRIPTION
Fixes #61

## Problem

`TestGetElement/Performance` (and similar performance subtests for `Set` and `Get`) intermittently fail on Go 1.24+ because the tolerance of `0.5 * res1.NsPerOp()` is too tight.

When the absolute timings are small (e.g., 48 ns/op), a 50% tolerance allows only 24 ns difference, but benchmark noise can easily exceed that:

```
Error: Max difference between 48 and 79 allowed is 24, but difference was -31
```

## Fix

Increase the tolerance from `0.5x` to `1.0x` the baseline. This still validates O(1) behavior (the 4x-larger map should complete within 2x the time of the smaller map) while being robust against benchmark variance on fast runtimes.

All tests pass.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/orderedmap/64)
<!-- Reviewable:end -->
